### PR TITLE
DAOS-8273 pmdk: Add a patch to be applied

### DIFF
--- a/DAOS_8273.patch
+++ b/DAOS_8273.patch
@@ -1,0 +1,29 @@
+diff --git a/src/libpmemobj/tx.c b/src/libpmemobj/tx.c
+index 2213dd04a..b0c723505 100644
+--- a/src/libpmemobj/tx.c
++++ b/src/libpmemobj/tx.c
+@@ -1053,6 +1053,7 @@ pmemobj_tx_end(void)
+ 	Free(txd);
+ 
+ 	VALGRIND_END_TX;
++	int ret = tx->last_errnum;
+ 
+ 	if (PMDK_SLIST_EMPTY(&tx->tx_entries)) {
+ 		ASSERTeq(tx->lane, NULL);
+@@ -1071,6 +1072,7 @@ pmemobj_tx_end(void)
+ 			tx->stage_callback_arg = NULL;
+ 
+ 			cb(tx->pop, TX_STAGE_NONE, arg);
++			/* tx should not be accessed after this callback */
+ 		}
+ 	} else {
+ 		/* resume the next transaction */
+@@ -1081,7 +1083,7 @@ pmemobj_tx_end(void)
+ 			obj_tx_abort(tx->last_errnum, 0);
+ 	}
+ 
+-	return tx->last_errnum;
++	return ret;
+ }
+ 
+ /*


### PR DESCRIPTION
This patch is set to be added to PMDK in this PMDK pull request:

https://github.com/pmem/pmdk/pull/5345

I'd like to commit it here to have a patch I can reference both
in this repository for RPM build and in daos build.config

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>