### PR TITLE
DAOS-11151 pmdk: Update PMDK rpm to 1.12.1rc1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,16 @@
+pmdk (1.12.1~rc1-1) unstable; urgency=medium
+
+  * Upgrade to 1.12.1~rc1
+  * Fixes DAOS-11151
+
+ -- Jeff Olivier <jeffrey.v.olivier@intel.com>  Tue, 16 Aug 2022 10:24:22 -0400
+
 pmdk (1.12.0-1) unstable; urgency=medium
 
   * Upgrade to 1.12.0
   * Remove rpmem packages
 
- -- Jeff Olivier <jeffrey.v.olivier@intel.com>  Tue, 26 Jul 2021 12:45:42 -0400
+ -- Jeff Olivier <jeffrey.v.olivier@intel.com>  Tue, 26 Jul 2022 12:45:42 -0400
 
 pmdk (1.11.0-2) unstable; urgency=medium
 

--- a/packaging/Dockerfile.ubuntu.20.04
+++ b/packaging/Dockerfile.ubuntu.20.04
@@ -17,7 +17,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
             autoconf bash ca-certificates curl debhelper dh-make        \
             dpkg-dev dh-python doxygen gcc git git-buildpackage locales \
             make patch pbuilder pkg-config python3-dev python3-distro   \
-            python3-distutils rpm scons wget cmake
+            python3-distutils rpm scons wget cmake valgrind
 
 # rpmdevtools
 RUN echo "deb [trusted=yes] ${REPO_URL}${REPO_UBUNTU_20_04} focal main" > /etc/apt/sources.list.d/daos-stack-ubuntu-stable-local.list

--- a/pmdk.spec
+++ b/pmdk.spec
@@ -15,6 +15,10 @@
     %define dist .suse%{suse_version}
 %endif
 
+%global major 1
+%global minor 12
+%global bugrelease 1
+%global prerelease rc1
 %global _hardened_build 1
 
 # by default build with ndctl, unless explicitly disabled
@@ -23,7 +27,7 @@
 %define min_ndctl_ver 60.1
 
 Name:       pmdk
-Version:    1.12.0
+Version:    %{major}.%{minor}.%{bugrelease}%{?prerelease:~%{prerelease}}
 Release:    1%{?dist}
 Summary:    Persistent Memory Development Kit
 Group:      System Environment/Libraries
@@ -643,6 +647,10 @@ cp utils/pmdk.magic %{buildroot}%{_datadir}/pmdk/
 
 
 %changelog
+* Tue Aug 16 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> - 1.12.1-1
+- Update to release 1.12.1~rc1
+- Fixes DAOS-11151
+
 * Tue Jul 26 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> - 1.12.0-1
 - Update to release 1.12.0
 - Remove rpmem packages


### PR DESCRIPTION
Fixes this major issue with reserve API
Also addresses the performance regression in 1.12.0

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>