### PR TITLE
DAOS-623 build: work around docker flock(2) issue

### DIFF
--- a/pmdk.spec
+++ b/pmdk.spec
@@ -604,7 +604,7 @@ cp utils/pmdk.magic %{buildroot}%{_datadir}/pmdk/
     %if %{defined _testconfig}
         cp %{_testconfig} src/test/testconfig.sh
     %else
-        echo "PMEM_FS_DIR=/tmp" > src/test/testconfig.sh
+        echo "PMEM_FS_DIR=/dev/shm" > src/test/testconfig.sh
         echo "PMEM_FS_DIR_FORCE_PMEM=1" >> src/test/testconfig.sh
         echo 'TEST_BUILD="debug nondebug"' >> src/test/testconfig.sh
         echo 'TEST_FS="pmem any none"' >> src/test/testconfig.sh


### PR DESCRIPTION
The daos-stack build system employs multiple levels of containerization and semi-containerization. One of these multi-level structures is built as follows:

host OS / `docker` (fedora:latest) / `mock` (centos+epel-7-x86_64)

Note: `mock` is effectively `chroot` + `rpmbuild`.

For an unknown reason and I do not know since when the overlay filesystem inside docker does not handle correctly flock(2) in the way it is used by libpmemobj. Because of it, the PMDK test fails and PMDK packages do not build as intended.

The PMDK packages are built according to `pmdk.spec` which configures also the test phase for `rpmbuild`. Prior to this change, all the files for the PMDK testing were created in the /tmp directory which is a well-established path to use for this purpose when the PMDK testing is conducted in a container or VM.

By default, docker does nothing special for this directory so it is just carved out from the overlay filesystem causing the PMDK test failure because of the flock(2) issue. The issue does not occur on tmpfs though. So, when testing PMDK inside a docker container is highly recommended to mount tmpfs under /tmp and use it for testing e.g.

```sh
docker run ... --tmpfs /tmp:rw,relatime,suid,dev,exec,size=6G ...
```

But, as mentioned before, the daos-stack build system also employs mock which builds its own root directory and because of the `chroot` also changes what `/tmp` path point to. Which is unrelated to how `/tmp` is constructed for the parent container.

From the inspection `/tmp` inside mock is just a part of the regular filesystem hence it will suffer from the overlay filesystem weakness. But mercifully `mock` mounts tmpfs under `/dev/shm`.

Hence, I recommend using `/dev/shm` to work around the docker's overlay filesystem issue in this case.