### PR TITLE
DAOS-16708 - provide PMDK pkg with NDCTL enabled (2.1.0-2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,6 @@ SRC_EXT       := gz
 TEST_PACKAGES := libpmem libpmem-devel libpmemobj libpmemobj-devel libpmempool \
 		 libpmempool-devel pmempool pmreorder
 
+EXTERNAL_RPM_BUILD_OPTIONS := --with=ndctl
+
 include packaging/Makefile_packaging.mk

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,4 @@ SRC_EXT       := gz
 TEST_PACKAGES := libpmem libpmem-devel libpmemobj libpmemobj-devel libpmempool \
 		 libpmempool-devel pmempool pmreorder
 
-EXTERNAL_RPM_BUILD_OPTIONS := --with=ndctl
-
 include packaging/Makefile_packaging.mk

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pmdk (2.1.0-2) stable; urgency=medium
+
+  * Enable NDCTL on the top of PMDK 2.1.0
+
+ -- Tomasz Gromadzki <tomasz.gromadzki@intel.com>  Thu, 08 Aug 2024 10:00:00 +0000
+
 pmdk (2.1.0-1) stable; urgency=medium
 
   * Update to release 2.1.0 w/o NDCTL support which:

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,8 +3,7 @@ pmdk (2.1.0-2) stable; urgency=medium
   * Enable NDCTL on the top of PMDK 2.1.0
     * remove an option to build PMDK w/o NDCTL.
 
-
- -- Tomasz Gromadzki <tomasz.gromadzki@intel.com>  Tue, 20 Aug 2024 10:00:00 +0000
+ -- Tomasz Gromadzki <tomasz.gromadzki@intel.com>  Wed, 04 Sep 2024 10:00:00 +0000
 
 pmdk (2.1.0-1) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,10 @@
 pmdk (2.1.0-2) stable; urgency=medium
 
   * Enable NDCTL on the top of PMDK 2.1.0
+    * remove an option to build PMDK w/o NDCTL.
 
- -- Tomasz Gromadzki <tomasz.gromadzki@intel.com>  Thu, 08 Aug 2024 10:00:00 +0000
+
+ -- Tomasz Gromadzki <tomasz.gromadzki@intel.com>  Tue, 20 Aug 2024 10:00:00 +0000
 
 pmdk (2.1.0-1) stable; urgency=medium
 

--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 DEB_UPSTREAM_VERSION = $(shell dpkg-parsechangelog -S version | cut -d - -f 1 | cut -d : -f 2)
 
-BUILD_ARGS = prefix=/usr libdir=/usr/lib/$(DEB_HOST_MULTIARCH) sysconfdir=/etc bashcompdir=/usr/share/bash-completion/completions NORPATH=1 BUILD_EXAMPLES=n BUILD_BENCHMARKS=n NDCTL_ENABLE=n PMEMOBJ_IGNORE_DIRTY_SHUTDOWN=y PMEMOBJ_IGNORE_BAD_BLOCKS=y
+BUILD_ARGS = prefix=/usr libdir=/usr/lib/$(DEB_HOST_MULTIARCH) sysconfdir=/etc bashcompdir=/usr/share/bash-completion/completions NORPATH=1 BUILD_EXAMPLES=n BUILD_BENCHMARKS=n VALGRIND=1
 
 %:
 	#dh $@ --with bash-completion
@@ -21,7 +21,7 @@ BUILD_ARGS = prefix=/usr libdir=/usr/lib/$(DEB_HOST_MULTIARCH) sysconfdir=/etc b
 # This dependency (libndctl, libdaxctl) is resolved after `db_auto_clean` step.
 #
 override_dh_auto_clean:
-	dh_auto_clean -- $(BUILD_ARGS) NDCTL_ENABLE=n PMEMOBJ_IGNORE_DIRTY_SHUTDOWN=y PMEMOBJ_IGNORE_BAD_BLOCKS=y
+	dh_auto_clean -- $(BUILD_ARGS) NDCTL_ENABLE=n PMEMOBJ_IGNORE_DIRTY_SHUTDOWN=y PMEMOBJ_IGNORE_BAD_BLOCKS=y VALGRIND=1
 	rm -rf src/test/unittest/__pycache__
 
 override_dh_auto_build:

--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 DEB_UPSTREAM_VERSION = $(shell dpkg-parsechangelog -S version | cut -d - -f 1 | cut -d : -f 2)
 
-BUILD_ARGS = prefix=/usr libdir=/usr/lib/$(DEB_HOST_MULTIARCH) sysconfdir=/etc bashcompdir=/usr/share/bash-completion/completions NORPATH=1 BUILD_EXAMPLES=n BUILD_BENCHMARKS=n VALGRIND=0
+BUILD_ARGS = prefix=/usr libdir=/usr/lib/$(DEB_HOST_MULTIARCH) sysconfdir=/etc bashcompdir=/usr/share/bash-completion/completions NORPATH=1 BUILD_EXAMPLES=n BUILD_BENCHMARKS=n
 
 %:
 	#dh $@ --with bash-completion
@@ -21,7 +21,7 @@ BUILD_ARGS = prefix=/usr libdir=/usr/lib/$(DEB_HOST_MULTIARCH) sysconfdir=/etc b
 # This dependency (libndctl, libdaxctl) is resolved after `db_auto_clean` step.
 #
 override_dh_auto_clean:
-	dh_auto_clean -- $(BUILD_ARGS) NDCTL_ENABLE=n PMEMOBJ_IGNORE_DIRTY_SHUTDOWN=y PMEMOBJ_IGNORE_BAD_BLOCKS=y VALGRIND=0
+	dh_auto_clean -- $(BUILD_ARGS) NDCTL_ENABLE=n PMEMOBJ_IGNORE_DIRTY_SHUTDOWN=y PMEMOBJ_IGNORE_BAD_BLOCKS=y
 	rm -rf src/test/unittest/__pycache__
 
 override_dh_auto_build:

--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 DEB_UPSTREAM_VERSION = $(shell dpkg-parsechangelog -S version | cut -d - -f 1 | cut -d : -f 2)
 
-BUILD_ARGS = prefix=/usr libdir=/usr/lib/$(DEB_HOST_MULTIARCH) sysconfdir=/etc bashcompdir=/usr/share/bash-completion/completions NORPATH=1 BUILD_EXAMPLES=n BUILD_BENCHMARKS=n VALGRIND=1
+BUILD_ARGS = prefix=/usr libdir=/usr/lib/$(DEB_HOST_MULTIARCH) sysconfdir=/etc bashcompdir=/usr/share/bash-completion/completions NORPATH=1 BUILD_EXAMPLES=n BUILD_BENCHMARKS=n VALGRIND=0
 
 %:
 	#dh $@ --with bash-completion
@@ -21,7 +21,7 @@ BUILD_ARGS = prefix=/usr libdir=/usr/lib/$(DEB_HOST_MULTIARCH) sysconfdir=/etc b
 # This dependency (libndctl, libdaxctl) is resolved after `db_auto_clean` step.
 #
 override_dh_auto_clean:
-	dh_auto_clean -- $(BUILD_ARGS) NDCTL_ENABLE=n PMEMOBJ_IGNORE_DIRTY_SHUTDOWN=y PMEMOBJ_IGNORE_BAD_BLOCKS=y VALGRIND=1
+	dh_auto_clean -- $(BUILD_ARGS) NDCTL_ENABLE=n PMEMOBJ_IGNORE_DIRTY_SHUTDOWN=y PMEMOBJ_IGNORE_BAD_BLOCKS=y VALGRIND=0
 	rm -rf src/test/unittest/__pycache__
 
 override_dh_auto_build:

--- a/pmdk.spec
+++ b/pmdk.spec
@@ -29,7 +29,7 @@
 %bcond_with ndctl
 
 %define min_ndctl_ver 63
-%define _make_common_args EXTRA_CFLAGS="-Wno-error" NORPATH=1 BUILD_EXAMPLES=n BUILD_BENCHMARKS=n VALGRIND=0
+%define _make_common_args EXTRA_CFLAGS="-Wno-error" NORPATH=1 BUILD_EXAMPLES=n BUILD_BENCHMARKS=n
 
 %if %{with ndctl}
     %define make_common_args %{_make_common_args}

--- a/pmdk.spec
+++ b/pmdk.spec
@@ -19,9 +19,7 @@
 %global _hardened_build 1
 
 %define min_ndctl_ver 63
-%define _make_common_args EXTRA_CFLAGS="-Wno-error" NORPATH=1 BUILD_EXAMPLES=n BUILD_BENCHMARKS=n
-
-%define make_common_args %{_make_common_args}
+%define make_common_args EXTRA_CFLAGS="-Wno-error" NORPATH=1 BUILD_EXAMPLES=n BUILD_BENCHMARKS=n
 
 Name:       pmdk
 Version:    %{major}.%{minor}.%{bugrelease}%{?prerelease:~%{prerelease}}
@@ -403,7 +401,7 @@ make %{make_common_args} check
 
 
 %changelog
-* Tue Aug 20 2024  Tomasz.Gromadzki <tomasz.gromadzki@intel.com> - 2.1.0-2
+* Wed Sep 04 2024  Tomasz.Gromadzki <tomasz.gromadzki@intel.com> - 2.1.0-2
 - Enable NDCTL on the top of PMDK 2.1.0
   - remove an option to build PMDK w/o NDCTL.
 

--- a/pmdk.spec
+++ b/pmdk.spec
@@ -1,7 +1,4 @@
 
-# rpmbuild options:
-#   --define _skip_check 1
-
 # do not terminate build if files in the $RPM_BUILD_ROOT
 # directory are not found in the %%files (without rpmem case)
 #define _unpackaged_files_terminate_build 0
@@ -9,9 +6,7 @@
 # Ignore an issue with unpackaged libpmem2 files
 %define _unpackaged_files_terminate_build 0
 
-# disable 'make check' on suse
 %if %{defined suse_version}
-    %define _skip_check 1
     %define dist .suse%{suse_version}
 %endif
 
@@ -378,16 +373,12 @@ cp utils/pmdk.magic %{buildroot}%{_datadir}/pmdk/
 
 
 %check
-%if 0%{?_skip_check} == 1
-    echo "Check skipped"
-%else
-    echo "PMEM_FS_DIR=/dev/shm" > src/test/testconfig.sh
-    echo "PMEM_FS_DIR_FORCE_PMEM=1" >> src/test/testconfig.sh
-    echo 'PMEMOBJ_CONF="sds.at_create=0"' >> src/test/testconfig.sh
-    echo 'TEST_BUILD="debug nondebug"' >> src/test/testconfig.sh
-    echo 'TEST_FS="pmem any none"' >> src/test/testconfig.sh
-    make %{make_common_args} check
-%endif
+echo "PMEM_FS_DIR=/dev/shm" > src/test/testconfig.sh
+echo "PMEM_FS_DIR_FORCE_PMEM=1" >> src/test/testconfig.sh
+echo 'PMEMOBJ_CONF="sds.at_create=0"' >> src/test/testconfig.sh
+echo 'TEST_BUILD="debug nondebug"' >> src/test/testconfig.sh
+echo 'TEST_FS="pmem any none"' >> src/test/testconfig.sh
+make %{make_common_args} check
 
 %if 0%{?suse_version} >= 01315
 %post   -n libpmem%{?libmajor} -p /sbin/ldconfig

--- a/pmdk.spec
+++ b/pmdk.spec
@@ -29,7 +29,7 @@
 %bcond_with ndctl
 
 %define min_ndctl_ver 63
-%define _make_common_args EXTRA_CFLAGS="-Wno-error" NORPATH=1 BUILD_EXAMPLES=n BUILD_BENCHMARKS=n VALGRIND=1
+%define _make_common_args EXTRA_CFLAGS="-Wno-error" NORPATH=1 BUILD_EXAMPLES=n BUILD_BENCHMARKS=n VALGRIND=0
 
 %if %{with ndctl}
     %define make_common_args %{_make_common_args}
@@ -401,6 +401,7 @@ cp utils/pmdk.magic %{buildroot}%{_datadir}/pmdk/
     %else
         echo "PMEM_FS_DIR=/dev/shm" > src/test/testconfig.sh
         echo "PMEM_FS_DIR_FORCE_PMEM=1" >> src/test/testconfig.sh
+        echo 'PMEMOBJ_CONF="sds.at_create=0"' >> src/test/testconfig.sh
         echo 'TEST_BUILD="debug nondebug"' >> src/test/testconfig.sh
         echo 'TEST_FS="pmem any none"' >> src/test/testconfig.sh
     %endif

--- a/pmdk.spec
+++ b/pmdk.spec
@@ -1,7 +1,5 @@
 
 # rpmbuild options:
-#   --with ndctl
-#   --define _testconfig <path to custom testconfig.sh>
 #   --define _skip_check 1
 
 # do not terminate build if files in the $RPM_BUILD_ROOT
@@ -25,17 +23,10 @@
 
 %global _hardened_build 1
 
-# by default build without ndctl, unless explicitly enabled
-%bcond_with ndctl
-
 %define min_ndctl_ver 63
 %define _make_common_args EXTRA_CFLAGS="-Wno-error" NORPATH=1 BUILD_EXAMPLES=n BUILD_BENCHMARKS=n
 
-%if %{with ndctl}
-    %define make_common_args %{_make_common_args}
-%else
-    %define make_common_args %{_make_common_args} NDCTL_ENABLE=n PMEMOBJ_IGNORE_DIRTY_SHUTDOWN=y PMEMOBJ_IGNORE_BAD_BLOCKS=y
-%endif
+%define make_common_args %{_make_common_args}
 
 Name:       pmdk
 Version:    %{major}.%{minor}.%{bugrelease}%{?prerelease:~%{prerelease}}
@@ -61,13 +52,11 @@ BuildRequires:  pandoc
 BuildRequires:  perl
 BuildRequires:  fdupes
 
-%if %{with ndctl}
 %if %{defined suse_version}
 BuildRequires:  libndctl-devel >= %{min_ndctl_ver}
 %else
 BuildRequires:  ndctl-devel >= %{min_ndctl_ver}
 BuildRequires:  daxctl-devel >= %{min_ndctl_ver}
-%endif
 %endif
 
 # Debug variants of the libraries should be filtered out of the provides.
@@ -335,8 +324,6 @@ state.
 %doc ChangeLog CONTRIBUTING.md README.md
 
 
-%if %{with ndctl}
-
 %package -n daxio
 Summary: Perform I/O on Device DAX devices or zero a Device DAX device
 Group: System Environment/Base
@@ -355,8 +342,6 @@ a device.
 %license LICENSE
 %doc ChangeLog CONTRIBUTING.md README.md
 
-# _with_ndctl
-%endif
 
 %prep
 %autosetup -p1 -n %{name}-%{upstream_version}
@@ -396,15 +381,11 @@ cp utils/pmdk.magic %{buildroot}%{_datadir}/pmdk/
 %if 0%{?_skip_check} == 1
     echo "Check skipped"
 %else
-    %if %{defined _testconfig}
-        cp %{_testconfig} src/test/testconfig.sh
-    %else
-        echo "PMEM_FS_DIR=/dev/shm" > src/test/testconfig.sh
-        echo "PMEM_FS_DIR_FORCE_PMEM=1" >> src/test/testconfig.sh
-        echo 'PMEMOBJ_CONF="sds.at_create=0"' >> src/test/testconfig.sh
-        echo 'TEST_BUILD="debug nondebug"' >> src/test/testconfig.sh
-        echo 'TEST_FS="pmem any none"' >> src/test/testconfig.sh
-    %endif
+    echo "PMEM_FS_DIR=/dev/shm" > src/test/testconfig.sh
+    echo "PMEM_FS_DIR_FORCE_PMEM=1" >> src/test/testconfig.sh
+    echo 'PMEMOBJ_CONF="sds.at_create=0"' >> src/test/testconfig.sh
+    echo 'TEST_BUILD="debug nondebug"' >> src/test/testconfig.sh
+    echo 'TEST_FS="pmem any none"' >> src/test/testconfig.sh
     make %{make_common_args} check
 %endif
 
@@ -431,8 +412,9 @@ cp utils/pmdk.magic %{buildroot}%{_datadir}/pmdk/
 
 
 %changelog
-* Thu Aug 08 2024  Tomasz.Gromadzki <tomasz.gromadzki@intel.com> - 2.1.0-2
+* Tue Aug 20 2024  Tomasz.Gromadzki <tomasz.gromadzki@intel.com> - 2.1.0-2
 - Enable NDCTL on the top of PMDK 2.1.0
+  - remove an option to build PMDK w/o NDCTL.
 
 * Tue Aug 06 2024  Tomasz.Gromadzki <tomasz.gromadzki@intel.com> - 2.1.0-1
 - Update to release 2.1.0 w/o NDCTL support which:

--- a/pmdk.spec
+++ b/pmdk.spec
@@ -21,7 +21,7 @@
 %global minor 1
 %global bugrelease 0
 #%%global prerelease rc1
-%global buildrelease 1
+%global buildrelease 2
 
 %global _hardened_build 1
 
@@ -29,7 +29,7 @@
 %bcond_with ndctl
 
 %define min_ndctl_ver 63
-%define _make_common_args EXTRA_CFLAGS="-Wno-error" NORPATH=1 BUILD_EXAMPLES=n BUILD_BENCHMARKS=n
+%define _make_common_args EXTRA_CFLAGS="-Wno-error" NORPATH=1 BUILD_EXAMPLES=n BUILD_BENCHMARKS=n VALGRIND=1
 
 %if %{with ndctl}
     %define make_common_args %{_make_common_args}
@@ -430,6 +430,9 @@ cp utils/pmdk.magic %{buildroot}%{_datadir}/pmdk/
 
 
 %changelog
+* Thu Aug 08 2024  Tomasz.Gromadzki <tomasz.gromadzki@intel.com> - 2.1.0-2
+- Enable NDCTL on the top of PMDK 2.1.0
+
 * Tue Aug 06 2024  Tomasz.Gromadzki <tomasz.gromadzki@intel.com> - 2.1.0-1
 - Update to release 2.1.0 w/o NDCTL support which:
   - Introduces the new logging subsystem in the release build for all libraries.


### PR DESCRIPTION
This PR create PMDK package with NDCTL.
Both the `master` (https://github.com/daos-stack/daos/pull/14371) and the `release/2.6` (https://github.com/daos-stack/daos/pull/15203) have been fixed to support NDCTL.