### PR TITLE
DAOS-16660 No error message on intentional pmemobj transaction abort

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,6 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@grom72/SRE-2736") _
 packageBuildingPipelineDAOSTest(['distros': ['el8', 'el9', 'leap15', 'ubuntu20.04'],
 				 'test-tag': 'pr daosio'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,5 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
-@Library(value="pipeline-lib@grom72/SRE-2736") _
 packageBuildingPipelineDAOSTest(['distros': ['el8', 'el9', 'leap15', 'ubuntu20.04'],
 				 'test-tag': 'pr daosio'])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,9 @@
 pmdk (2.1.0-3) stable; urgency=medium
-  * Use patch to avoid anoing error message on intentional transaction abort.
-  * Use patch to avoid anoing error message on PMDK used with non-PMem HW.
+  * Apply patches to silence annoying error messages on:
+    * an intentional transaction abort and
+    * PMDK being used with non-PMem HW.
 
- -- Tomasz Gromadzki <tomasz.gromadzki@intel.com>  Thu, 24 Oct 2024 10:00:00 +0000
-
+ -- Tomasz Gromadzki <tomasz.gromadzki@intel.com>  Wed, 06 Nov 2024 10:00:00 +0000
 
 pmdk (2.1.0-2) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+pmdk (2.1.0-3) stable; urgency=medium
+  * Use patch to avoid anoing error message on intentional transaction abort.
+  * Use patch to avoid anoing error message on PMDK used with non-PMem HW.
+
+ -- Tomasz Gromadzki <tomasz.gromadzki@intel.com>  Thu, 24 Oct 2024 10:00:00 +0000
+
+
 pmdk (2.1.0-2) stable; urgency=medium
 
   * Enable NDCTL on the top of PMDK 2.1.0

--- a/packaging/Makefile_distro_vars.mk
+++ b/packaging/Makefile_distro_vars.mk
@@ -91,6 +91,14 @@ DISTRO_VERSION  ?= $(VERSION_ID)
 ORIG_TARGET_VER := 15.5
 SED_EXPR        := 1p
 endif
+ifeq ($(CHROOT_NAME),opensuse-leap-15.6-x86_64)
+VERSION_ID      := 15.6
+DISTRO_ID       := sl15.6
+DISTRO_BASE     := LEAP_15
+DISTRO_VERSION  ?= $(VERSION_ID)
+ORIG_TARGET_VER := 15.6
+SED_EXPR        := 1p
+endif
 endif
 ifeq ($(ID),centos)
 ID = el

--- a/packaging/get_base_branch
+++ b/packaging/get_base_branch
@@ -4,7 +4,7 @@
 
 set -eux -o pipefail
 IFS=' ' read -r -a add_bases <<< "${1:-}"
-origin=origin
+origin="${ORIGIN:-origin}"
 mapfile -t all_bases < <(echo "master"
                          git branch -r | sed -ne "/^  $origin\\/release\\/[0-9]/s/^  $origin\\///p")
 all_bases+=("${add_bases[@]}")

--- a/pmdk.spec
+++ b/pmdk.spec
@@ -410,10 +410,10 @@ make %{make_common_args} check
 
 
 %changelog
-* Wed Oct 23 2024  Tomasz Gromadzki <tomasz.gromadzki@intel.com> - 2.1.0-3
-- use patch to avoid anoing error message on intentional transaction abort.
-- use patch to avoid anoing error message on PMDK used with non-PMem HW.
-
+* Wed Nov 06 2024  Tomasz Gromadzki <tomasz.gromadzki@intel.com> - 2.1.0-3
+- Apply patches to silence annoying error messages on:
+  - an intentional transaction abort and
+  - PMDK being used with non-PMem HW.
 
 * Wed Sep 04 2024  Tomasz.Gromadzki <tomasz.gromadzki@intel.com> - 2.1.0-2
 - Enable NDCTL on the top of PMDK 2.1.0

--- a/pmdk.spec
+++ b/pmdk.spec
@@ -16,7 +16,7 @@
 %global minor 1
 %global bugrelease 0
 #%%global prerelease rc1
-%global buildrelease 2
+%global buildrelease 3
 
 %global _hardened_build 1
 
@@ -37,6 +37,13 @@ URL:        https://github.com/pmem/pmdk
 }
 
 Source:     https://github.com/pmem/%{name}/releases/download/%{upstream_version}/%{name}-%{upstream_version}.tar.gz
+%if "%{?commit}" != ""
+Patch0: %{version}..%{commit}.patch
+%endif
+# Fix https://github.com/pmem/pmdk/issues/6107 : Annoying error message on user intentional transaction abort
+Patch1: https://github.com/pmem/pmdk/commit/61e32285370e629e2b36bbb991b919e44f87d915.patch
+# Fix https://github.com/pmem/pmdk/issues/6126 : Unnecessary warning: "Cannot find any matching device, no bad blocks found" for non-pmem HW
+Patch2: https://github.com/pmem/pmdk/commit/518b7426a13b21f98b2d2c435fa645770899446a.patch
 
 BuildRequires:  gcc
 BuildRequires:  make
@@ -403,11 +410,16 @@ make %{make_common_args} check
 
 
 %changelog
+* Wed Oct 23 2024  Tomasz Gromadzki <tomasz.gromadzki@intel.com> - 2.1.0-3
+- use patch to avoid anoing error message on intentional transaction abort.
+- use patch to avoid anoing error message on PMDK used with non-PMem HW.
+
+
 * Wed Sep 04 2024  Tomasz.Gromadzki <tomasz.gromadzki@intel.com> - 2.1.0-2
 - Enable NDCTL on the top of PMDK 2.1.0
   - remove an option to build PMDK w/o NDCTL.
 
-* Tue Aug 06 2024  Tomasz.Gromadzki <tomasz.gromadzki@intel.com> - 2.1.0-1
+* Tue Aug 06 2024  Tomasz Gromadzki <tomasz.gromadzki@intel.com> - 2.1.0-1
 - Update to release 2.1.0 w/o NDCTL support which:
   - Introduces the new logging subsystem in the release build for all libraries.
   - Messages by default are printed to syslog and stderr but might be redirected to a user-defined function, see pmem(obj)_log_set_function() for details.


### PR DESCRIPTION
There are a few unnecessary warning messages generated by libpmemobj, which may cause misinterpretation of library behavior.

They are already disabled in the PMDK:
https://github.com/pmem/pmdk/pull/6127
https://github.com/pmem/pmdk/pull/6117